### PR TITLE
Add setup script and development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Development Standards for fastset
+
+This document defines the contribution standards and development workflow for agents interacting with this repository.
+
+## Commit Message Standard
+- Use **Conventional Commits** (`type: description`), e.g. `feat: add paging support`.
+- Common types: `feat`, `fix`, `perf`, `refactor`, `docs`, `style`, `test`, `ci`, `build`, `chore`.
+- Keep messages concise (72 characters or less for the summary).
+- Provide additional context in the commit body when necessary.
+
+## Commit Sequencing
+- Group related changes into atomic commits.
+- Order commits logically (tests and docs can accompany related code changes).
+
+## Pull Request Standards
+- Title mirrors the main commit summary.
+- Description should include:
+  - Purpose of the change
+  - Summary of implementation
+  - Testing steps and results
+  - References to issues or discussions if applicable
+- PRs must pass `cargo fmt -- --check`, `cargo clippy -- -D warnings`, and `cargo test`.
+
+## Code Housekeeping
+- Update dependencies periodically using `cargo update`.
+- Remove dead code and keep the codebase tidy.
+- Address technical debt as part of regular maintenance.
+
+## Architecture and Design
+- Keep modules small and focused.
+- Document public APIs in code using Rust doc comments.
+- Avoid introducing unsafe code unless absolutely necessary and document its use.
+
+## Pre-commit Checks
+Run the following before committing:
+```bash
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+## Version Management
+- Follow [SemVer](https://semver.org/) for crate versions in `Cargo.toml`.
+- Tag releases with `vMAJOR.MINOR.PATCH`.
+- Document changes in `CHANGELOG.md` under an "Unreleased" section until release.
+
+## CHANGELOG Maintenance
+- Add an entry for any user-facing change.
+- Use subsections: `Added`, `Changed`, `Fixed`, `Removed`, `Security`.
+
+## Testing Standards
+- Keep unit tests in `src/` alongside modules.
+- Ensure test coverage for new features.
+- Benchmarks reside in `bench/` and are run with `cargo bench`.
+
+## Documentation
+- Update `README.md` when public APIs or usage change.
+- Keep inline documentation up to date with code changes.
+

--- a/README.md
+++ b/README.md
@@ -120,3 +120,9 @@ Fast set implementation for dense, bounded integer collections, offering quick u
  [1]: **Chakraborty, Sourav, N. V. Vinodchandran, and Kuldeep S. Meel.** *"Distinct Elements in Streams: An Algorithm for the (Text) Book."* arXiv preprint arXiv:2301.10191 (2023).
 
  [2]: **Meel, Kuldeep S., Sourav Chakraborty, and N. V. Vinodchandran.** *"Estimation of the Size of Union of Delphic Sets: Achieving Independence from Stream Size."* Proceedings of the 41st ACM SIGMOD-SIGACT-SIGAI Symposium on Principles of Database Systems. 2022.
+
+## Development Setup
+
+Run `./setup-dev.sh` once with internet access to prepare a fully
+offline development environment. The script installs Rust, fetches all
+crate dependencies, and runs the test suite.

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup script for fastset development environment
+# Installs Rust toolchain and fetches crate dependencies for offline work.
+
+# Detect package manager
+if command -v apt-get >/dev/null; then
+    PM_UPDATE="apt-get update"
+    PM_INSTALL="apt-get install -y"
+else
+    echo "Unsupported package manager. Please install build-essential, curl, and git manually." >&2
+    exit 1
+fi
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+# Install OS packages
+$SUDO $PM_UPDATE
+$SUDO $PM_INSTALL build-essential curl git pkg-config libssl-dev
+
+# Install rustup if not already installed
+if ! command -v rustup >/dev/null; then
+    echo "Installing rustup..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    export PATH="$HOME/.cargo/bin:$PATH"
+else
+    echo "rustup already installed"
+fi
+
+# Ensure cargo bin path is in PATH for future sessions
+if ! grep -q cargo/bin ~/.bashrc; then
+    echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+fi
+
+# Install stable toolchain and common components
+rustup install stable
+rustup default stable
+rustup component add clippy rustfmt
+
+# Prefetch crate dependencies for offline work
+cargo fetch
+
+# Run tests to verify everything works
+cargo test
+
+echo "Development environment setup complete." 


### PR DESCRIPTION
## Summary
- provide an offline development setup script
- document contribution standards
- explain how to use the setup script in `README`

## Testing
- `./setup-dev.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684947444390832ba4b2e7935399d0fe